### PR TITLE
ex_list_snapshots paginates in OpenStack_2

### DIFF
--- a/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__snapshots_paginate_start.json
+++ b/libcloud/test/compute/fixtures/openstack_v1.1/_v2_0__snapshots_paginate_start.json
@@ -1,4 +1,10 @@
 {
+    "snapshots_links": [
+      {
+        "href": "https://api.example.com:8776/v2/abcdec85bee34bb0a44ab8255eb36fbd/snapshots?&marker=abcde279-4cc0-4b47-a4ee-ec9c9e474b1b",
+        "rel": "next"
+      }
+    ],
     "snapshots": [
         {
             "status": "available",
@@ -6,8 +12,8 @@
                 "name": "test"
             },
             "os-extended-snapshot-attributes:progress": "100%",
-            "name": "snap-001",
-            "volume_id": "373f7b48-c4c1-4e70-9acc-086b39073506",
+            "name": "snap-101",
+            "volume_id": "473f7b48-c4c1-4e70-9acc-086b39073506",
             "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
             "created_at": "2012-02-29T03:50:07Z",
             "size": 1,
@@ -17,29 +23,29 @@
         {
             "status": "available",
             "metadata": {
-                "name": "test"
+                "name": "test2"
             },
             "os-extended-snapshot-attributes:progress": "100%",
-            "name": "test-volume-snapshot",
-            "volume_id": "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+            "name": "test-volume-snapshot2",
+            "volume_id": "7edbc2f4-1507-44f8-ac0d-eed1d2608d38",
             "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
             "created_at": "2015-11-29T02:25:51.000000",
             "size": 1,
-            "id": "4fbbdccf-e058-6502-8844-6feeffdf4cb5",
+            "id": "5fbbdccf-e058-6502-8844-6feeffdf4cb5",
             "description": "volume snapshot"
         },
         {
             "status": "available",
             "metadata": {
-                "name": "test"
+                "name": "test2"
             },
             "os-extended-snapshot-attributes:progress": "100%",
             "name": "test-volume-snapshot",
-            "volume_id": "373f7b48-c4c1-4e70-9acc-086b39073506",
+            "volume_id": "473f7b48-c4c1-4e70-9acc-086b39073506",
             "os-extended-snapshot-attributes:project_id": "bab7d5c60cd041a0a36f7c4b6e1dd978",
             "created_at": "2013-02-29T03:50:07Z",
             "size": 1,
-            "id": "1fbbcccf-d058-4502-8844-6feeffdf4cb5",
+            "id": "2fbbcccf-d058-4502-8844-6feeffdf4cb5",
             "description": "volume snapshot"
         }
     ]

--- a/libcloud/test/compute/test_openstack.py
+++ b/libcloud/test/compute/test_openstack.py
@@ -20,6 +20,7 @@ import sys
 import unittest
 import datetime
 import pytest
+
 from libcloud.utils.iso8601 import UTC
 
 try:
@@ -47,7 +48,8 @@ from libcloud.compute.drivers.openstack import (
     OpenStack_1_1_FloatingIpAddress, OpenStackKeyPair,
     OpenStack_1_0_Connection, OpenStack_2_FloatingIpPool,
     OpenStackNodeDriver,
-    OpenStack_2_NodeDriver, OpenStack_2_PortInterfaceState, OpenStackNetwork)
+    OpenStack_2_NodeDriver, OpenStack_2_PortInterfaceState, OpenStackNetwork,
+    OpenStackException)
 from libcloud.compute.base import Node, NodeImage, NodeSize
 from libcloud.pricing import set_pricing, clear_pricing_data
 
@@ -1617,6 +1619,32 @@ class OpenStack_2_Tests(OpenStack_1_1_Tests):
         # normally authentication happens lazily, but we force it here
         self.driver.volumev2_connection._populate_hosts_and_request_paths()
 
+    def test__paginated_request_single_page(self):
+        snapshots = self.driver._paginated_request(
+            '/snapshots/detail', 'snapshots',
+            self.driver.volumev2_connection
+        )['snapshots']
+
+        self.assertEqual(len(snapshots), 3)
+        self.assertEqual(snapshots[0]['name'], 'snap-001')
+
+    def test__paginated_request_two_pages(self):
+        snapshots = self.driver._paginated_request(
+            '/snapshots/detail?unit_test=paginate', 'snapshots',
+            self.driver.volumev2_connection
+        )['snapshots']
+
+        self.assertEqual(len(snapshots), 6)
+        self.assertEqual(snapshots[0]['name'], 'snap-101')
+        self.assertEqual(snapshots[3]['name'], 'snap-001')
+
+    def test__paginated_request_raises_if_stuck_in_a_loop(self):
+        with pytest.raises(OpenStackException):
+            self.driver._paginated_request(
+                '/snapshots/detail?unit_test=pagination_loop', 'snapshots',
+                self.driver.volumev2_connection
+            )
+
     def test_ex_force_auth_token_passed_to_connection(self):
         base_url = 'https://servers.api.rackspacecloud.com/v1.1/slug'
         kwargs = {
@@ -2468,7 +2496,11 @@ class OpenStack_1_1_MockHttp(MockHttp, unittest.TestCase):
             return (httplib.NO_CONTENT, body, self.json_content_headers, httplib.responses[httplib.OK])
     
     def _v2_1337_snapshots_detail(self, method, url, body, headers):
-        body = self.fixtures.load('_v2_0__snapshots.json')
+        if ('unit_test=paginate' in url and 'marker' not in url) or \
+                'unit_test=pagination_loop' in url:
+            body = self.fixtures.load('_v2_0__snapshots_paginate_start.json')
+        else:
+            body = self.fixtures.load('_v2_0__snapshots.json')
         return (httplib.OK, body, self.json_content_headers, httplib.responses[httplib.OK])
 
     def _v2_1337_snapshots(self, method, url, body, headers):


### PR DESCRIPTION
the default max_limits for OpenStack is 1000. If you have more than 1000
resources (in this case snapshots) then everything but the newest 1000
will not be listed. If you set the max_limits lower even less will not
be returned, etc. This change implements pagination for ex_list_snapshots
in the OpenStack_2_NodeDriver. Later I will expand on this by implementing
this pagination also for other methods in this driver.

WIP